### PR TITLE
Pass ClassName through to equalizer div

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react", "stage-2"]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-jest": "^6.0.1",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
     "jest-cli": "^0.8.2",
     "react-addons-test-utils": "^0.14.7"
   }

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,17 @@ This is a basic example which equalizes height of child components.
   <tbody>
     <tr>
       <td>
+        <code>className</code>
+      </td>
+      <td>
+        <code>[empty]</code>
+      </td>
+      <td>
+        Class of the equalizer container
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>property</code>
       </td>
       <td>

--- a/src/equalizer.js
+++ b/src/equalizer.js
@@ -66,7 +66,7 @@ export default class Equalizer extends Component {
   }
 
   updateChildrenHeights() {
-    const { property, byRow, enabled } = this.props
+    const { property, byRow, enabled, ...other } = this.props
     const node = ReactDOM.findDOMNode(this)
 
     if (!enabled(this, node)) {
@@ -89,7 +89,7 @@ export default class Equalizer extends Component {
 
   render() {
     return (
-      <div className={this.props.className ? this.props.className : null}>
+      <div {...other}>
         {this.props.children}
       </div>
     )

--- a/src/equalizer.js
+++ b/src/equalizer.js
@@ -89,7 +89,7 @@ export default class Equalizer extends Component {
 
   render() {
     return (
-      <div>
+      <div className={this.props.className ? this.props.className : null}>
         {this.props.children}
       </div>
     )

--- a/src/equalizer.js
+++ b/src/equalizer.js
@@ -66,7 +66,7 @@ export default class Equalizer extends Component {
   }
 
   updateChildrenHeights() {
-    const { property, byRow, enabled, ...other } = this.props
+    const { property, byRow, enabled } = this.props
     const node = ReactDOM.findDOMNode(this)
 
     if (!enabled(this, node)) {
@@ -89,7 +89,7 @@ export default class Equalizer extends Component {
 
   render() {
     return (
-      <div {...other}>
+      <div {...this.props}>
         {this.props.children}
       </div>
     )


### PR DESCRIPTION
I've made this modification so an additional div will not be needed to apply a class to the equalizer group
