### PR TITLE
fix offsetTop, remove lodash debounce dependency, use imported PropTypes

### DIFF
--- a/__tests__/equalizer-test.js
+++ b/__tests__/equalizer-test.js
@@ -8,47 +8,67 @@ const Equalizer = require('../src/equalizer').default;
 
 const getMaxHeight = (heights) => heights[heights.length-1]
 
+const mockFactory = function(values) {
+  return function(){
+    return values
+  }
+}
+
 describe('Equalizer', () => {
   let inlineNodes, stackedNodes;
 
   beforeEach(function() {
     inlineNodes = [
       {
-        offsetTop: 0,
-        offsetHeight: 50,
+        getBoundingClientRect: mockFactory({
+          top: 0,
+          height: 50
+        }),
         style: {}
       },
       {
-        offsetTop: 0,
-        offsetHeight: 150,
+        getBoundingClientRect: mockFactory({
+          top: 0,
+          height: 150
+        }),
         style: {}
       },
       {
-        offsetTop: 0,
-        offsetHeight: 100,
+        getBoundingClientRect: mockFactory({
+          top: 0,
+          height: 100
+        }),
         style: {}
       }
     ]
 
     stackedNodes = [
       {
-        offsetTop: 0,
-        offsetHeight: 50,
+        getBoundingClientRect: mockFactory({
+          top: 0,
+          height: 50
+        }),
         style: {}
       },
       {
-        offsetTop: 0,
-        offsetHeight: 100,
+        getBoundingClientRect: mockFactory({
+          top: 0,
+          height: 100
+        }),
         style: {}
       },
       {
-        offsetTop: 200,
-        offsetHeight: 125,
+        getBoundingClientRect: mockFactory({
+          top: 200,
+          height: 125
+        }),
         style: {}
       },
       {
-        offsetTop: 200,
-        offsetHeight: 50,
+        getBoundingClientRect: mockFactory({
+          top: 200,
+          height: 50
+        }),
         style: {}
       }
     ]

--- a/__tests__/equalizer-test.js
+++ b/__tests__/equalizer-test.js
@@ -8,33 +8,27 @@ const Equalizer = require('../src/equalizer').default;
 
 const getMaxHeight = (heights) => heights[heights.length-1]
 
-const mockFactory = function(values) {
-  return function(){
-    return values
-  }
-}
-
 describe('Equalizer', () => {
   let inlineNodes, stackedNodes;
 
   beforeEach(function() {
     inlineNodes = [
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 0,
           height: 50
         }),
         style: {}
       },
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 0,
           height: 150
         }),
         style: {}
       },
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 0,
           height: 100
         }),
@@ -44,28 +38,28 @@ describe('Equalizer', () => {
 
     stackedNodes = [
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 0,
           height: 50
         }),
         style: {}
       },
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 0,
           height: 100
         }),
         style: {}
       },
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 200,
           height: 125
         }),
         style: {}
       },
       {
-        getBoundingClientRect: mockFactory({
+        getBoundingClientRect: () => ({
           top: 200,
           height: 50
         }),

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     ]
   },
   "dependencies": {
-    "lodash.debounce": "^4.0.3"
   },
   "peerDependencies": {
     "react": ">0.14.0",

--- a/src/equalizer.js
+++ b/src/equalizer.js
@@ -1,6 +1,25 @@
 import React, { Component, PropTypes } from 'react'
 import ReactDOM from 'react-dom'
-import debounce from 'lodash.debounce'
+
+// http://stackoverflow.com/a/24004942
+function debounce(func, wait, immediate) {
+  let timeout
+  return function() {
+    let context = this
+    let args = arguments
+    let callNow = immediate && !timeout
+    clearTimeout(timeout)
+    timeout = setTimeout(function() {
+      timeout = null
+      if (!immediate) {
+        func.apply(context, args);
+      }
+    }, wait)
+    if (callNow) {
+      func.apply(context, args)
+    }
+  }
+}
 
 export default class Equalizer extends Component {
   constructor(){
@@ -40,8 +59,8 @@ export default class Equalizer extends Component {
       node.style.maxHeight = ''
       node.style.minHeight = ''
 
-      const elOffsetTop = node.offsetTop
-      const elHeight    = node.offsetHeight
+      // http://ejohn.org/blog/getboundingclientrect-is-awesome/
+      const {top: elOffsetTop, height: elHeight} = node.getBoundingClientRect();
 
       if(i === 0) {
         lastElTopOffset = elOffsetTop
@@ -105,9 +124,9 @@ Equalizer.defaultProps = {
 }
 
 Equalizer.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  property: React.PropTypes.string,
-  byRow:    React.PropTypes.bool,
-  enabled:  React.PropTypes.func,
-  nodes:    React.PropTypes.func
+  children: PropTypes.node.isRequired,
+  property: PropTypes.string,
+  byRow:    PropTypes.bool,
+  enabled:  PropTypes.func,
+  nodes:    PropTypes.func
 }


### PR DESCRIPTION
I was having a problem where the `node.offsetTop` was reporting 0 in all cases (Chrome Version 55.0.2883.95 (64-bit) on OSX), so fixed that, and tweaked a couple of other things.